### PR TITLE
fix: [domain] - change key

### DIFF
--- a/domain-api/src/main/java/com/ashjang/domain/utils/Aes256Utils.java
+++ b/domain-api/src/main/java/com/ashjang/domain/utils/Aes256Utils.java
@@ -9,7 +9,7 @@ import java.nio.charset.StandardCharsets;
 
 public class Aes256Utils {
     public static String alg = "AES/CBC/PKCS5Padding";
-    private static final String KEY = "THISISFINTECHPROJECTFOLLOWME";
+    private static final String KEY = "THISISFINTECHPROJECTUSINGFORKEYS";
     private static final String IV = KEY.substring(0,16);
 
     public static String encrypt(String text) {


### PR DESCRIPTION
Changes
---

- key 28bytes -> 32bytes

Study
---

Aes256은 16,24,32bytes 길이를 갖는 key를 가지는 대칭형 암호 알고리즘.